### PR TITLE
A program which lists environment variables as '=' delimited key/value pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # Go-getenv
 Get Environment variables in Go language
+
+Written a program which lists environment variables as '=' delimited key/value pairs using Go language.
+
+Below are the references taken - 
+https://play-with-go.dev/get-started-with-go_go115_en/
+https://zetcode.com/golang/env/

--- a/prnenv.go
+++ b/prnenv.go
@@ -1,12 +1,17 @@
 package main
-
+// Import required packages
 import (
     "fmt"
     "os"
 )
 
+// Main function - entry point
 func main() {
 
+    /*
+     * Get list of all environmental variables. Go through each
+     * using a for loop and print it.
+     */
     for _, e := range os.Environ() {
         fmt.Printf("%s\n",e)
     }

--- a/prnenv.go
+++ b/prnenv.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+    "fmt"
+    "os"
+)
+
+func main() {
+
+    for _, e := range os.Environ() {
+        fmt.Printf("%s\n",e)
+    }
+}


### PR DESCRIPTION
Created a program in Go which lists environment variables as '=' delimited key/value pairs.
For example -
```

PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

HOSTNAME=e6a0557d8a1b

```
Unit test -
Tested in https://go.dev/play/ editor